### PR TITLE
fix: lazy-load grammars for syntax-highlighting

### DIFF
--- a/config/syntax-highlighter.config.js
+++ b/config/syntax-highlighter.config.js
@@ -1,8 +1,12 @@
-/** @typedef {import("shiki").BuiltinTheme} BuiltinTheme */
+/** @typedef {import("@shikijs/rehype").RehypeShikiOptions} RehypeShikiOptions */
 
-/** @type {import("shiki").CodeOptionsThemes<BuiltinTheme>} */
+/** @type {RehypeShikiOptions} */
 export const config = {
 	defaultColor: "light",
+	defaultLanguage: "text",
+	/** Languages are lazy-loaded on demand. */
+	langs: [],
+	lazy: true,
 	themes: {
 		light: "github-light",
 		dark: "github-dark",


### PR DESCRIPTION
currently, there is a noticable delay when initially loading an mdx-rendered page, because the `shiki` syntax highlighter is initializing all supported grammars.

this pr makes `shiki` load grammars lazily on demand.