### PR TITLE
test: use meta tag content in opengraph image test

### DIFF
--- a/e2e/tests/app/metadata.test.ts
+++ b/e2e/tests/app/metadata.test.ts
@@ -110,21 +110,15 @@ test("should add json+ld metadata", async ({ createIndexPage }) => {
 	}
 });
 
-// eslint-disable-next-line playwright/no-skipped-test
-test.skip("should serve an open-graph image", async ({ createIndexPage, request }) => {
+test("should serve an open-graph image", async ({ createIndexPage, request }) => {
 	for (const locale of locales) {
-		const imagePath = `/${locale}/opengraph-image`;
-
 		const { indexPage } = await createIndexPage(locale);
 		await indexPage.goto();
-		await expect(indexPage.page.locator('meta[property="og:image"]')).toHaveAttribute(
-			"content",
-			expect.stringContaining(
-				`${String(createUrl({ baseUrl: env.NEXT_PUBLIC_APP_BASE_URL, pathname: imagePath }))}?`,
-			),
-		);
 
-		const response = await request.get(imagePath);
+		const url = await indexPage.page.locator('meta[property="og:image"]').getAttribute("content");
+		expect(url).toContain(`/${locale}/opengraph-image`);
+
+		const response = await request.get(String(url));
 		const status = response.status();
 		const contentType = response.headers()["content-type"];
 


### PR DESCRIPTION
this fixes the skipped opengraph image test, which currently just tries to request `/:locale/opengraph-image`.

however, when using route groups, next.js adds a hash to the filename, because "./app/(app)/opengraph-image" and "./app/opengraph-image" would resolve to the same file.

we fix the test by more correctly looking up the `content` attribute of `<meta property="og:image">` and using that url, which includes any added hash, to try to request the image.